### PR TITLE
Update expiration date

### DIFF
--- a/_data/jobs.yaml
+++ b/_data/jobs.yaml
@@ -410,7 +410,7 @@
   title: Community Manager
   url: https://illinois.csod.com/ux/ats/careersite/1/home/requisition/3113?c=illinois
 - employer: University of Delaware
-  expires: 5/1/2023
+  expires: 6/1/2023
   job_type: Full-Time
   location: Remote
   posted: 2/7/2023


### PR DESCRIPTION
Update expiration date for NCSA community manager oosting to 6/1/2023.