### PR TITLE
fixing jobs rendering with expire date

### DIFF
--- a/_includes/jobrows.html
+++ b/_includes/jobrows.html
@@ -1,11 +1,9 @@
 {% capture jobs_data %}
   {% for job in include.sorted_jobs %}
-  {% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-  {% capture expires %}{{ job.expires | date: "%m/%d/%Y" | date: '%s'}}{% endcapture %}
+  {% capture nowunix %}{{'now' | date: '%m/%d/%Y' | date: %s }}{% endcapture %}
   {% capture posted %}{{ job.posted | date: "%m/%d/%Y" | date: '%b %d, %Y'}}{% endcapture %}
   {% capture posted_order %}{{ job.posted | date: "%m/%d/%Y" | date: '%Y%m%d'}}{% endcapture %}
   {% capture expires_order %}{{ job.expires | date: "%m/%d/%Y" | date: '%Y%m%d'}}{% endcapture %}
-  {% if expires > nowunix %}
     <tr class='tr odd {% cycle "odd" "even" %}' data-posted="{{ posted_order }}" data-expires="{{ expires_order }}">
      <td data-order="{{ job.title }}" ><a target="_blank" href="{{ job.url }}">{{ job.title }}</a></td>
      <td data-order="{{ job.job_type }}" >{{ job.job_type }}</td>
@@ -15,7 +13,7 @@
      <td data-order="{{ posted_order }}" >{{ job.posted }}</td>
      <td data-order="{{ job.remote }}" >{{ job.remote }}</td>
     </tr>
-  {% endif %}{% endfor %}
+  {% endfor %}
 {% endcapture %}
 {% comment %}
 This accounts for the way whitespace appears in

--- a/pages/index.md
+++ b/pages/index.md
@@ -65,7 +65,7 @@ permalink: /
       <th data-sortable="true" data-field="job-type" width="15%">Job Type</th>
       <th data-sortable="true" data-field="location" width="15%">Employer</th>
       <th data-sortable="true" data-field="location" width="15%">Location</th>
-      <th data-sortable="true" data-field="expires">Expires</th>
+      <th data-sortable="true" data-field="expires">Advertised Until</th>
       <th data-sortable="true" data-field="posted" width="10%">Posted</th>
       <th data-sortable="true" data-field="remote" width="10%">Remote Options</th>
    </tr>


### PR DESCRIPTION
problem: not all jobs are showing up
solution: the bug is inconsitent rendering of the expires date, which depending on how it is provided can be rendered correctly as a timestamp, or if jekyll cannot, it falls back to a date format that cannot pass the comparison. In practice this results in a lot of missing jobs, and introduces potential for many errors. A better solution is to rely on what we already have, parsing the dates and expires in the python automation, and then allowing for 60 days of buffer (so jobs are shown that go 60 days back). To allow for this we have updated the "Expires" heading to be "Advertised until"