### PR TITLE
Fix DL Communications locations

### DIFF
--- a/_data/jobs.yaml
+++ b/_data/jobs.yaml
@@ -141,8 +141,7 @@
 - employer: Rivos Inc.
   expires: 10/31/2024
   job_type: Full-Time
-  location: '"Santa Clara, CA", "Austin, TX", "Portland, OR", "Fort Collins, CO",
-    "Cambridge, UK", "Remote"'
+  location: Santa Clara CA, Austin TX, Portland OR, Fort Collins CO, Cambridge UK, Remote
   posted: 9/20/2024
   remote: Remote friendly
   title: DL Communications Collectives SW Engineer


### PR DESCRIPTION
Data entry seems to have included multiple quotation marks both single and double. Changed manually to exclude quotation marks. An alternative to this PR would be to sanitize the input more thoroughly.