### PR TITLE
Use ISO-8601 date format

### DIFF
--- a/_data/jobs.yaml
+++ b/_data/jobs.yaml
@@ -1,237 +1,237 @@
 - employer: Tactical Computing Labs
-  expires: 1/31/2025
+  expires: 2025-01-31
   job_type: Full-Time
   location: Remote
-  posted: 1/31/2023
+  posted: 2023-01-31
   remote: Fully remote
   title: HPC SIMULATION DEVELOPER
   url: https://tactcomplabs.com/jobs/hpc-simulation-developer/
 - employer: Microsoft
-  expires: 11/30/2024
+  expires: 2024-11-30
   job_type: Full-Time
   location: USA
-  posted: 8/13/2024
+  posted: 2024-08-13
   remote: Fully remote
   title: HPC/AI Customer Innovations Engineer
   url: https://jobs.careers.microsoft.com/global/en/share/1745712/?utm_source=Job
     Share&utm_campaign=Copy-job-share
 - employer: Microsoft
-  expires: 11/30/2024
+  expires: 2024-11-30
   job_type: Full-Time
   location: Remote
-  posted: 8/14/2024
+  posted: 2024-08-14
   remote: Fully remote
   title: Principal Software Engineer - HPC Benchmarking, Applications, and Workflows
   url: https://jobs.careers.microsoft.com/global/en/share/1752931/?utm_source=Job
     Share&utm_campaign=Copy-job-share
 - employer: Microsoft
-  expires: 11/30/2024
+  expires: 2024-11-30
   job_type: Full-Time
   location: Remote
-  posted: 8/15/2024
+  posted: 2024-08-15
   remote: Fully remote
   title: Senior Software Engineer - HPC Programming Environments
   url: https://jobs.careers.microsoft.com/global/en/job/1753103/Senior-Software-Engineer---HPC-Programming-Environments
 - employer: Microsoft
-  expires: 12/1/2024
+  expires: 2024-12-01
   job_type: Full-Time
   location: Remote
-  posted: 8/16/2024
+  posted: 2024-08-16
   remote: Fully remote
   title: HPC Software Engineer
   url: https://jobs.careers.microsoft.com/global/en/share/1750679/?utm_source=Job
     Share&utm_campaign=Copy-job-share
 - employer: Microsoft
-  expires: 12/1/2024
+  expires: 2024-12-01
   job_type: Full-Time
   location: Remote
-  posted: 8/16/2024
+  posted: 2024-08-16
   remote: Fully remote
   title: HPC Benchmarking Engineer II
   url: https://jobs.careers.microsoft.com/global/en/share/1753114/?utm_source=Job
     Share&utm_campaign=Copy-job-share
 - employer: Microsoft
-  expires: 12/12/2024
+  expires: 2024-12-12
   job_type: Full-Time
   location: USA
-  posted: 9/12/2024
+  posted: 2024-09-12
   remote: Remote friendly
   title: HPC Technical Consultant
   url: https://jobs.careers.microsoft.com/global/en/job/1763188/High-Performance-Computing-(HPC)-Technical-Consultant
 - employer: Pittsburgh Supercomputing Center
-  expires: 4/30/2025
+  expires: 2025-04-30
   job_type: Full-Time
   location: Pittsburgh, PA
-  posted: 10/2/2024
+  posted: 2024-10-02
   remote: Hybrid
   title: Infrastructure Engineer
   url: https://cmu.wd5.myworkdayjobs.com/en-US/CMU/job/Pittsburgh-PA/Infrastructure-Engineer---MCS---Pittsburgh-Supercomputing-Center--PSC-_2022386
 - employer: Kforce
-  expires: 12/12/2025
+  expires: 2025-12-12
   job_type: Full-Time
   location: Remote
-  posted: 10/8/2024
+  posted: 2024-10-08
   remote: Remote friendly
   title: Senior Systems Engineer (HPC, Linux, Storage)
   url: https://www.kforce.com/find-work/search-jobs/#/detail/MTY5Nn5BUUd-MjEyNDUxN1Axfjk5/
 - employer: New Mexico State University
-  expires: 12/15/2024
+  expires: 2024-12-15
   job_type: Full-Time
   location: Las Cruces, New Mexico
-  posted: 11/18/2024
+  posted: 2024-11-18
   remote: Fully onsite
   title: Director of Research Computing and Data Science
   url: https://jobs.sciencecareers.org/job/666573/director-of-research-computing-and-data-science-/?LinkSource=PremiumListing
 - employer: Rice University
-  expires: 1/15/2025
+  expires: 2025-01-15
   job_type: Full-Time
   location: Houston, TX
-  posted: 11/20/2024
+  posted: 2024-11-20
   remote: Fully onsite
   title: Director, Center for Research Computing
   url: https://emdz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001/requisitions/preview/4278/?lastSelectedFacet=CATEGORIES&selectedCategoriesFacet=300000008971178
 - employer: Together AI
-  expires: 1/22/2025
+  expires: 2025-01-22
   job_type: Full-Time
   location: San Francisco, CA
-  posted: 11/22/2024
+  posted: 2024-11-22
   remote: Fully onsite
   title: Systems Engineer
   url: https://job-boards.greenhouse.io/togetherai/jobs/4544420007
 - employer: University of Delaware
-  expires: 12/31/2024
+  expires: 2024-12-31
   job_type: Full-Time
   location: Newark, Delaware
-  posted: 11/24/2024
+  posted: 2024-11-24
   remote: Hybrid
   title: Research Software Engineer
   url: https://careers.udel.edu/cw/en-us/job/501450/research-software-engineer
 - employer: University of Manitoba / Alliance Federation
-  expires: 12/11/2024
+  expires: 2024-12-11
   job_type: Full-Time
   location: Winnipeg, MB
-  posted: 11/29/2024
+  posted: 2024-11-29
   remote: Remote friendly
   title: Cloud Computing and High-Throughput Computing Specialist
   url: https://viprecprod.ad.umanitoba.ca/DEFAULT.ASPX?REQ_ID=36426
 - employer: Texas Tech University High Performance Computing Center
-  expires: 12/20/2024
+  expires: 2024-12-20
   job_type: Full-Time
   location: Lubbock, TX USA
-  posted: 12/2/2024
+  posted: 2024-12-02
   remote: Fully onsite
   title: Research Associate
   url: https://www.depts.ttu.edu/hpcc/employment.php
 - employer: Microsoft
-  expires: 1/1/2025
+  expires: 2025-01-01
   job_type: Full-Time
   location: Remote
-  posted: 12/2/2024
+  posted: 2024-12-02
   remote: Remote friendly
   title: Senior Software Engineer, HPC Infrastructure
   url: https://jobs.careers.microsoft.com/global/en/share/1787492/?utm_source=Job%20Share&utm_campaign=Copy-job-share
 - employer: University of ZÃ¼rich
-  expires: 3/2/2025
+  expires: 2025-03-02
   job_type: Full-Time
   location: ZÃ¼rich, Switzerland
-  posted: 12/7/2024
+  posted: 2024-12-07
   remote: Fully onsite
   title: System Engineer / System Administrator for Science IT (m/f/x) 80 - 100 %
   url: https://jobs.uzh.ch/job-vacancies/system-engineer-system-administrator-for-science-it-m-f-x/b176f89d-fe9e-4dde-b565-fa3148237745
 - employer: University of Leicester
-  expires: 12/1/2024
+  expires: 2024-12-01
   job_type: Full-Time
   location: Leicester, UK
-  posted: 12/7/2024
+  posted: 2024-12-07
   remote: Fully onsite
   title: Professor/Associate Professor in Distributed Computing
   url: https://jobs.le.ac.uk/vacancies/10370/professor-associate-professor-in-distributed-computing.html
 - employer: Amazon Web Services
-  expires: 2/28/2025
+  expires: 2025-02-28
   job_type: Full-Time
   location: SWE, Stockholm
-  posted: 12/19/2024
+  posted: 2024-12-19
   remote: Fully onsite
   title: "Sr. GTM Specialist â\x80\x93 HPC Europe North"
   url: https://amazon.jobs/en/jobs/2855727/sr-gtm-specialist-hpc-europe-north
 - employer: Merck KGaA, Darmstadt, Germany
-  expires: 1/31/2025
+  expires: 2025-01-31
   job_type: Full-Time
   location: Boston (US) or Darmstadt (DE)
-  posted: 12/20/2024
+  posted: 2024-12-20
   remote: Remote friendly
   title: (Senior) Scientific Applications Engineer
   url: https://careers.merckgroup.com/global/en/job/282721/-Senior-Scientific-Applications-Engineer-all-genders
 - employer: Merck KGaA, Darmstadt, Germany
-  expires: 1/31/2025
+  expires: 2025-01-31
   job_type: Full-Time
   location: Boston (US) or Darmstadt (DE)
-  posted: 12/20/2024
+  posted: 2024-12-20
   remote: Remote friendly
   title: (Senior) Machine Learning Platform Engineer
   url: https://careers.merckgroup.com/global/en/job/282722/-Senior-Machine-Learning-Platform-Engineer-all-genders
 - employer: HPC2N, UmeÃ¥ University
-  expires: 3/31/2025
+  expires: 2025-03-31
   job_type: Full-Time
   location: UmeÃ¥, Sweden
-  posted: 12/21/2024
+  posted: 2024-12-21
   remote: Remote friendly
   title: System developer/devops for academic HPC
   url: https://umu.varbi.com/en/what:job/jobID:782028/
 - employer: Columbia University
-  expires: 1/20/2025
+  expires: 2025-01-20
   job_type: Full-Time
   location: New York, NY
-  posted: 1/5/2025
+  posted: 2025-01-05
   remote: Hybrid
   title: Senior Systems Engineer
   url: https://opportunities.columbia.edu/cw/en-us/job/548210
 - employer: University of Bristol
-  expires: 12/11/2024
+  expires: 2024-12-11
   job_type: Full-Time
   location: Bristol, UK
-  posted: 11/20/2024
+  posted: 2024-11-20
   remote: Hybrid
   title: Research Associate / Senior Research Associate in High Performance Computing
   url: https://www.bristol.ac.uk/jobs/find/details/?jobId=368409&jobTitle=Research%20Associate%20/%20Senior%20Research%20Associate%20in%20High%20Performance%20Computing
 - employer: Center for Advanced Systems Understanding (CASUS) / Helmholtz-Zentrum
     Dresden-Rossendorf (HZDR)
-  expires: 2/27/2025
+  expires: 2025-02-27
   job_type: Full-Time
   location: Goerlitz / Saxony / Germany
-  posted: 1/13/2025
+  posted: 2025-01-13
   remote: Hybrid
   title: PhD Student (f/m/d) GPU-Computing for HPC und AI
   url: https://www.hzdr.de/db/Cms?pNid=490&pOid=73689&pContLang=en
 - employer: Massachusetts Technology Collaborative
-  expires: 2/14/2025
+  expires: 2025-02-14
   job_type: Full-Time
   location: Boston or Westborough, Massachusetts at least two days per week
-  posted: 1/14/2025
+  posted: 2025-01-14
   remote: Hybrid
   title: Acting Director of the Massachusetts Artificial Intelligence Hub
   url: https://apply.workable.com/masstech/j/FD73DA461F/
 - employer: Cornell University Center for Advanced Computing
-  expires: 2/28/2025
+  expires: 2025-02-28
   job_type: Full-Time
   location: Ithaca, NY
-  posted: 1/17/2025
+  posted: 2025-01-17
   remote: Hybrid
   title: Assistant Director for Systems and Operations
   url: https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/details/Assistant-Director--CAC-Systems-and-Operations_WDR-00050904-1
 - employer: KTH Royal Institute of Technology
-  expires: 2/20/2025
+  expires: 2025-02-20
   job_type: Full-Time
   location: Stockholm, Sweden
-  posted: 1/24/2025
+  posted: 2025-01-24
   remote: Remote friendly
   title: HPC Research Scientist
   url: https://kth.varbi.com/en/what:job/jobID:790896/
 - employer: New York University'
-  expires: 12/5/2024
+  expires: 2024-12-05
   job_type: Full-Time
   location: New York, NY
-  posted: 9/5/2024
+  posted: 2024-09-05
   remote: Remote friendly
   title: Senior HPC Specialist
   url: https://uscareers-nyu.icims.com/jobs/13834/job

--- a/_includes/jobrows.html
+++ b/_includes/jobrows.html
@@ -1,16 +1,14 @@
 {% capture jobs_data %}
   {% for job in include.sorted_jobs %}
-  {% capture nowunix %}{{'now' | date: '%m/%d/%Y' | date: %s }}{% endcapture %}
-  {% capture posted %}{{ job.posted | date: "%m/%d/%Y" | date: '%b %d, %Y'}}{% endcapture %}
-  {% capture posted_order %}{{ job.posted | date: "%m/%d/%Y" | date: '%Y%m%d'}}{% endcapture %}
-  {% capture expires_order %}{{ job.expires | date: "%m/%d/%Y" | date: '%Y%m%d'}}{% endcapture %}
-    <tr class='tr odd {% cycle "odd" "even" %}' data-posted="{{ posted_order }}" data-expires="{{ expires_order }}">
+  {% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
+  {% capture expires %}{{ job.expires | date: '%b %d, %Y' }}{% endcapture %}
+    <tr class='tr odd {% cycle "odd" "even" %}' data-posted="{{ job.posted }}" data-expires="{{ job.expires }}">
      <td data-order="{{ job.title }}" ><a target="_blank" href="{{ job.url }}">{{ job.title }}</a></td>
      <td data-order="{{ job.job_type }}" >{{ job.job_type }}</td>
      <td data-order="{{ job.employer }}" >{{ job.employer }}</td>
      <td data-order="{{ job.location }}" >{{ job.location }}</td>
-     <td data-order="{{ expires_order }}" >{{ job.expires }}</td>
-     <td data-order="{{ posted_order }}" >{{ job.posted }}</td>
+     <td data-order="{{ job.expires }}" >{{ expires }}</td>
+     <td data-order="{{ job.posted }}" >{{ posted }}</td>
      <td data-order="{{ job.remote }}" >{{ job.remote }}</td>
     </tr>
   {% endfor %}

--- a/assets/js/jobs.js
+++ b/assets/js/jobs.js
@@ -109,12 +109,11 @@ $(document).ready(function() {
 
     // Posted after (min)
     $('#min').on('change', function () {
-       var from = $(this).val().replace(/\//g, ''); //remove the slashes
-       var num = 4;
-       var result = from.substr(num) + from.substr(0, num);
+       const min_date = Date.parse($(this).val());
        $.fn.dataTable.ext.search.push(
-         function(settings, data, dataIndex) {           
-           return $(table.row(dataIndex).node()).attr('data-posted') >= result;
+         function(settings, data, dataIndex) {
+           const cur = $(table.row(dataIndex).node()).attr('data-posted');
+           return Date.parse(cur) >= min_date;
        });
        table.draw();
     });

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -144,13 +144,13 @@ def parse_lines(lines):
     jobs = []
     for line in lines:
         line = [x.strip() for x in line.split("\t")]
-        posted = line[0].split(" ")[0].strip()
+        posted = datetime.datetime.strptime(line[0].split(" ")[0].strip(), "%Y/%m/%d").isoformat()
         title = line[1].replace('"', "'")
         url = line[2].strip()
         location = line[3].strip()
         job_type = line[4].strip()
         remote = line[5].strip()
-        expires = line[6].strip()
+        expires = datetime.datetime.strptime(line[6].strip(), "%Y/%m/%d").isoformat()
         employer = line[7].strip()
 
         # If we have a url and key, check if
@@ -199,15 +199,13 @@ def update_jobs(file):
 
     # Keep a list to re-write to file
     keepers = []
-    now = datetime.date.today()
-    now = datetime.datetime.strptime(f"{now.year}/{now.month}/{now.day}", "%Y/%m/%d")
+    
+    now = datetime.date.today().isoformat()
 
     print("Found %s jobs" % len(jobs))
     for job in jobs:
-        expires = datetime.datetime.strptime(job["expires"], "%m/%d/%Y")
-
         # Do not keep expired jobs that haven't been updated in 60 days
-        if expires < now:
+        if job["expires"] < now:
             removal_date = expires + timedelta(days=60)
             if removal_date < now:
                 print(
@@ -217,7 +215,7 @@ def update_jobs(file):
                 continue
 
         # catch these and fail
-        if expires > now:
+        if job["expires"] > now:
             print("Keeping %s, expires in future." % job["title"])
             keepers.append(job)
             continue


### PR DESCRIPTION
I couldn't find official documentation, but all resources point to this SO post:

https://stackoverflow.com/questions/30933741/jekyll-cant-sort-collection-by-date

The job importer (scripts/update_jobs.py) is untested.

Fixes #1